### PR TITLE
add additional (required) permissions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,8 @@
 # Upgrade Notes
 
+## 3.2.1
+- [IMPROVEMENT] Add `pages_read_engagement` and `pages_read_user_content` as default permission to read page posts/feed
+
 ## 3.2.0
 - [IMPROVEMENT] Update to graph `v22.0`
 

--- a/src/Definition/ConnectorDefinition.php
+++ b/src/Definition/ConnectorDefinition.php
@@ -51,7 +51,7 @@ class ConnectorDefinition implements ConnectorDefinitionInterface
     {
         $resolver = new OptionsResolver();
         $resolver->setDefaults([
-            'api_connect_permission' => ['pages_show_list']
+            'api_connect_permission' => ['pages_show_list', 'pages_read_engagement', 'pages_read_user_content']
         ]);
 
         $resolver->setAllowedTypes('api_connect_permission', 'string[]');


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | --

Add `pages_read_engagement` and `pages_read_user_content` as default permission to read page posts/feed

https://developers.facebook.com/docs/features-reference/page-public-content-access/